### PR TITLE
Notification/test/issue/33 : 알림전송 worker, 재전송 worker, 실패 메시지 관리 큐 등 리팩토링 및 일부 테스트

### DIFF
--- a/core/core-notification/src/main/java/com/barlow/notification/worker/FailureMessageRetryQueue.java
+++ b/core/core-notification/src/main/java/com/barlow/notification/worker/FailureMessageRetryQueue.java
@@ -1,37 +1,28 @@
 package com.barlow.notification.worker;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MessagingErrorCode;
 
 public class FailureMessageRetryQueue {
 
-	private static final int DELAY_IN_MILLIS = 60_000;
-	private static final int MAX_RETRY_COUNT = 1;
-
 	private final DelayQueue<RetryBatchMessages> retryQueue;
+	private final int delayInMillis;
+	private final int maxRetryCount;
 
-	public FailureMessageRetryQueue() {
+	public FailureMessageRetryQueue(int delayInMillis, int maxRetryCount) {
 		this.retryQueue = new DelayQueue<>();
+		this.delayInMillis = delayInMillis;
+		this.maxRetryCount = maxRetryCount;
 	}
 
-	public void pushAll(Map<Message, FirebaseMessagingException> failMessageWithException) {
-		List<Message> retryableMessages = failMessageWithException.entrySet()
-			.stream()
-			.filter(entry -> entry.getValue().getMessagingErrorCode().equals(MessagingErrorCode.INTERNAL)
-				|| entry.getValue().getMessagingErrorCode().equals(MessagingErrorCode.UNAVAILABLE)
-				|| entry.getValue().getMessagingErrorCode().equals(MessagingErrorCode.QUOTA_EXCEEDED))
-			.map(Map.Entry::getKey)
-			.toList();
-		retryQueue.put(new RetryBatchMessages(retryableMessages, DELAY_IN_MILLIS, MAX_RETRY_COUNT));
+	public void pushAllRetryableMessages(List<Message> retryableMessages) {
+		retryQueue.put(new RetryBatchMessages(retryableMessages, delayInMillis, maxRetryCount));
 	}
 
 	public RetryBatchMessages take() throws InterruptedException {
@@ -58,8 +49,12 @@ public class FailureMessageRetryQueue {
 			this.retryCount = retryCount;
 		}
 
-		public List<Message> getRetryMessages() {
+		public List<Message> getMessages() {
 			return retryMessages;
+		}
+
+		public int size() {
+			return retryMessages.size();
 		}
 
 		public int getRetryCount() {

--- a/core/core-notification/src/main/java/com/barlow/notification/worker/NotificationResult.java
+++ b/core/core-notification/src/main/java/com/barlow/notification/worker/NotificationResult.java
@@ -1,0 +1,46 @@
+package com.barlow.notification.worker;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+
+public record NotificationResult(
+	Map<Message, MessagingErrorCode> result
+) {
+	boolean hasFailure() {
+		return !result.isEmpty();
+	}
+
+	boolean hasRetryableFailure() {
+		return result.entrySet()
+			.stream()
+			.filter(entry -> entry.getValue().equals(MessagingErrorCode.INTERNAL)
+				|| entry.getValue().equals(MessagingErrorCode.UNAVAILABLE)
+				|| entry.getValue().equals(MessagingErrorCode.QUOTA_EXCEEDED))
+			.map(Map.Entry::getKey)
+			.findAny()
+			.isPresent();
+	}
+
+	List<Message> getRetryableMessages() {
+		return result.entrySet()
+			.stream()
+			.filter(entry -> entry.getValue().equals(MessagingErrorCode.INTERNAL)
+				|| entry.getValue().equals(MessagingErrorCode.UNAVAILABLE)
+				|| entry.getValue().equals(MessagingErrorCode.QUOTA_EXCEEDED))
+			.map(Map.Entry::getKey)
+			.toList();
+	}
+
+	List<Message> getNonRetryableMessages() {
+		return result.entrySet()
+			.stream()
+			.filter(entry -> !entry.getValue().equals(MessagingErrorCode.INTERNAL)
+				&& !entry.getValue().equals(MessagingErrorCode.UNAVAILABLE)
+				&& !entry.getValue().equals(MessagingErrorCode.QUOTA_EXCEEDED))
+			.map(Map.Entry::getKey)
+			.toList();
+	}
+}

--- a/core/core-notification/src/main/java/com/barlow/notification/worker/NotificationSendWorker.java
+++ b/core/core-notification/src/main/java/com/barlow/notification/worker/NotificationSendWorker.java
@@ -62,7 +62,11 @@ public class NotificationSendWorker {
 					))
 				)
 				.toList();
-			notificationSender.send(messages);
+			NotificationResult notificationResult = notificationSender.send(messages);
+			if (notificationResult.hasFailure()) {
+				RetryWorker retryWorker = new RetryWorker(asyncThreadPoolExecutor, notificationSender);
+				retryWorker.start(notificationResult);
+			}
 		};
 	}
 }

--- a/core/core-notification/src/main/java/com/barlow/notification/worker/NotificationSender.java
+++ b/core/core-notification/src/main/java/com/barlow/notification/worker/NotificationSender.java
@@ -1,5 +1,6 @@
 package com.barlow.notification.worker;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -9,79 +10,64 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.api.core.ApiFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.SendResponse;
 
 public abstract class NotificationSender {
 
 	private static final Logger log = LoggerFactory.getLogger(NotificationSender.class);
-	private static final FailureMessageRetryQueue FAILURE_MESSAGE_RETRY_QUEUE = new FailureMessageRetryQueue();
 
 	protected final FirebaseMessaging firebaseMessaging;
 
 	protected NotificationSender(FirebaseMessaging firebaseMessaging) {
 		this.firebaseMessaging = firebaseMessaging;
-		this.startRetryWorker();
 	}
 
-	protected void send(List<Message> messages) {
+	protected NotificationResult send(List<Message> messages) {
 		ApiFuture<BatchResponse> batchResponseFuture = firebaseMessaging.sendEachAsync(messages);
-		Runnable callback = createCallbackTask(batchResponseFuture, messages);
-		batchResponseFuture.addListener(callback, MoreExecutors.directExecutor());
+		BatchResponse batchResponse = getBatchResponse(batchResponseFuture);
+		List<SendResponse> sendResponses = batchResponse.getResponses();
+		Map<Message, MessagingErrorCode> failedMessages = extractFailedMessages(messages, sendResponses);
+		if (!failedMessages.isEmpty()) {
+			logFailedMessages(failedMessages);
+			return new NotificationResult(failedMessages);
+		} else {
+			log.info("{} : 알림 전송 성공", LocalDateTime.now());
+			return new NotificationResult(Map.of());
+		}
 	}
 
-	protected Runnable createCallbackTask(ApiFuture<BatchResponse> batchResponseFuture, List<Message> messages) {
-		return () -> {
-			try {
-				BatchResponse batchResponse = batchResponseFuture.get();
-				List<SendResponse> sendResponses = batchResponse.getResponses();
-				Map<Message, FirebaseMessagingException> failMessageWithException = sendResponses.stream()
-					.filter(sendResponse -> !sendResponse.isSuccessful())
-					.collect(Collectors.toMap(
-						sendResponse -> messages.get(sendResponses.indexOf(sendResponse)),
-						SendResponse::getException
-					));
-				failMessageWithException.forEach((message, e) ->
-					log.info("실패 message: {}. Reason: {}", message, e.getMessage(), e)
-				);
-				FAILURE_MESSAGE_RETRY_QUEUE.pushAll(failMessageWithException);
-			} catch (InterruptedException e) {
-				log.warn("알림 전송 쓰레드 - {} 에서 문제 발생 : {}", Thread.currentThread().getName(), e.getMessage(), e);
-				Thread.currentThread().interrupt();
-			} catch (ExecutionException e) {
-				log.warn("알림 전송 쓰레드 - {} 에서 문제 발생 : {}", Thread.currentThread().getName(), e.getMessage(), e);
-			}
-		};
+	private BatchResponse getBatchResponse(ApiFuture<BatchResponse> batchResponseFuture) {
+		try {
+			return batchResponseFuture.get();
+		} catch (InterruptedException e) {
+			log.warn("알림 결과 조회 중 인터럽트됨: {} - 원인 : {}", e.getMessage(), e);
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			log.error("알림 결과 조회 중 문제 발생: {} - 원인: {}", cause.getClass().getSimpleName(), cause.getMessage(), cause);
+		}
+		throw new IllegalStateException("커스텀 예외 만들어서 던질게~"); // todo : 예외처리 다시 하기
 	}
 
-	protected void startRetryWorker() {
-		Runnable retryTask = () -> {
-			while (true) {
-				try {
-					FailureMessageRetryQueue.RetryBatchMessages retryBatchMessages = FAILURE_MESSAGE_RETRY_QUEUE.take();
-					if (retryBatchMessages.getRetryCount() > 0) {
-						retryBatchMessages.decrementRetryCount();
-						log.info("전송 실패 메시지 재전송...{}", retryBatchMessages.getRetryMessages());
-						send(retryBatchMessages.getRetryMessages());
-						log.info("남은 재시도 횟수 {}. 실패 메시지 재시도 큐 clear", retryBatchMessages.getRetryCount());
-						FAILURE_MESSAGE_RETRY_QUEUE.clear();
-					} else {
-						FAILURE_MESSAGE_RETRY_QUEUE.clear();
-						log.info("재시도 횟수 초과. 실패 메시지 재시도 큐 clear");
-					}
-				} catch (InterruptedException e) {
-					log.warn("알림 재전송 쓰레드 - {} 에서 문제 발생 : {}", Thread.currentThread().getName(), e.getMessage(), e);
-					Thread.currentThread().interrupt();
-					break;
-				}
-			}
-		};
-		Thread retryWorker = new Thread(retryTask);
-		retryWorker.setDaemon(true);
-		retryWorker.start();
+	private Map<Message, MessagingErrorCode> extractFailedMessages(
+		List<Message> messages,
+		List<SendResponse> sendResponses
+	) {
+		return sendResponses.stream()
+			.filter(sendResponse -> !sendResponse.isSuccessful())
+			.collect(Collectors.toMap(
+				sendResponse -> messages.get(sendResponses.indexOf(sendResponse)),
+				sendResponse1 -> sendResponse1.getException().getMessagingErrorCode()
+			));
+	}
+
+	private void logFailedMessages(Map<Message, MessagingErrorCode> failedMessages) {
+		failedMessages.forEach((message, errorCode) ->
+			log.info("실패 메시지: {}. 원인: {}", message, errorCode)
+		);
 	}
 }

--- a/core/core-notification/src/main/java/com/barlow/notification/worker/RetryWorker.java
+++ b/core/core-notification/src/main/java/com/barlow/notification/worker/RetryWorker.java
@@ -1,0 +1,74 @@
+package com.barlow.notification.worker;
+
+import java.util.concurrent.Executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RetryWorker {
+
+	private static final Logger log = LoggerFactory.getLogger(RetryWorker.class);
+	private static final FailureMessageRetryQueue FAILURE_MESSAGE_RETRY_QUEUE
+		= new FailureMessageRetryQueue(60_000, 1);
+
+	private final Executor executor;
+	private final NotificationSender notificationSender;
+
+	public RetryWorker(Executor executor, NotificationSender notificationSender) {
+		this.executor = executor;
+		this.notificationSender = notificationSender;
+	}
+
+	public void start(NotificationResult result) {
+		logNonRetryableMessages(result);
+		FAILURE_MESSAGE_RETRY_QUEUE.pushAllRetryableMessages(result.getRetryableMessages());
+		executor.execute(() -> {
+			while (!Thread.currentThread().isInterrupted()) {
+				try {
+					FailureMessageRetryQueue.RetryBatchMessages retryBatchMessages = FAILURE_MESSAGE_RETRY_QUEUE.take();
+					if (retryBatchMessages.getRetryCount() > 0) {
+						retryBatchMessages.decrementRetryCount();
+						log.info("실패 메시지 {}개 재전송...{}", retryBatchMessages.size(), retryBatchMessages.getMessages());
+						NotificationResult retryResult = notificationSender.send(retryBatchMessages.getMessages());
+
+						log.info("남은 재시도 횟수 {}. 실패 메시지 재시도 큐 clear", retryBatchMessages.getRetryCount());
+						FAILURE_MESSAGE_RETRY_QUEUE.clear();
+
+						handleRetryResult(retryBatchMessages, retryResult);
+					} else {
+						FAILURE_MESSAGE_RETRY_QUEUE.clear();
+						Thread.currentThread().interrupt();
+						log.info("재시도 횟수 초과. 실패 메시지 재시도 큐 clear");
+					}
+				} catch (InterruptedException e) {
+					log.warn("알림 재전송 쓰레드 - {} 에서 문제 발생 : {}", Thread.currentThread().getName(), e.getMessage(), e);
+					FAILURE_MESSAGE_RETRY_QUEUE.clear();
+					Thread.currentThread().interrupt();
+					break;
+				}
+			}
+		});
+	}
+
+	private void handleRetryResult(
+		FailureMessageRetryQueue.RetryBatchMessages retryBatchMessages,
+		NotificationResult retryResult
+	) {
+		logNonRetryableMessages(retryResult);
+		if (retryBatchMessages.getRetryCount() != 0 && retryResult.hasRetryableFailure()) {
+			FAILURE_MESSAGE_RETRY_QUEUE.pushAllRetryableMessages(retryResult.getRetryableMessages());
+		} else if (retryBatchMessages.getRetryCount() == 0 && retryResult.hasRetryableFailure()) {
+			log.info("재시도 가능한 dead letter 발생 : {}", retryResult.getRetryableMessages());
+			FAILURE_MESSAGE_RETRY_QUEUE.clear();
+		} else {
+			Thread.currentThread().interrupt();
+			FAILURE_MESSAGE_RETRY_QUEUE.clear();
+			log.info("재시도 완료 후 RetryWorker 종료");
+		}
+	}
+
+	private void logNonRetryableMessages(NotificationResult result) {
+		result.getNonRetryableMessages()
+			.forEach(message -> log.info("재시도 불가능한 실패 메시지 : {}", message));
+	}
+}

--- a/core/core-notification/src/test/java/com/barlow/notification/worker/FailureMessageRetryQueueTest.java
+++ b/core/core-notification/src/test/java/com/barlow/notification/worker/FailureMessageRetryQueueTest.java
@@ -1,0 +1,46 @@
+package com.barlow.notification.worker;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.google.firebase.messaging.Message;
+
+class FailureMessageRetryQueueTest {
+
+	private FailureMessageRetryQueue testRetryQueue;
+	private List<Message> retryableMessages;
+
+	@BeforeEach
+	void setUp() {
+		testRetryQueue = new FailureMessageRetryQueue(0, 1);
+		retryableMessages = List.of(
+			Message.builder().setToken("test").build(),
+			Message.builder().setToken("test").build(),
+			Message.builder().setToken("test").build()
+		);
+	}
+
+	@DisplayName("재시도 가능한 실패 메시지들을 queue 에 삽입한다")
+	@Test
+	void pushAllRetryableMessages() throws InterruptedException {
+		testRetryQueue.pushAllRetryableMessages(retryableMessages);
+
+		assertThat(testRetryQueue.isEmpty()).isFalse();
+		assertThat(testRetryQueue.take()).isInstanceOf(FailureMessageRetryQueue.RetryBatchMessages.class);
+	}
+
+	@DisplayName("실패 메시지 재시도 queue 를 비운다")
+	@Test
+	void clear() {
+		testRetryQueue.pushAllRetryableMessages(retryableMessages);
+
+		testRetryQueue.clear();
+
+		assertThat(testRetryQueue.isEmpty()).isTrue();
+	}
+}

--- a/core/core-notification/src/test/java/com/barlow/notification/worker/NotificationResultTest.java
+++ b/core/core-notification/src/test/java/com/barlow/notification/worker/NotificationResultTest.java
@@ -1,0 +1,65 @@
+package com.barlow.notification.worker;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+
+class NotificationResultTest {
+
+	private final Map<Message, MessagingErrorCode> failedMessages = Map.of(
+		Message.builder().setToken("test").build(), MessagingErrorCode.THIRD_PARTY_AUTH_ERROR,
+		Message.builder().setToken("test").build(), MessagingErrorCode.INVALID_ARGUMENT,
+		Message.builder().setToken("test").build(), MessagingErrorCode.INTERNAL,
+		Message.builder().setToken("test").build(), MessagingErrorCode.QUOTA_EXCEEDED,
+		Message.builder().setToken("test").build(), MessagingErrorCode.SENDER_ID_MISMATCH,
+		Message.builder().setToken("test").build(), MessagingErrorCode.UNAVAILABLE,
+		Message.builder().setToken("test").build(), MessagingErrorCode.UNREGISTERED
+	);
+	private final NotificationResult result = new NotificationResult(failedMessages);
+
+	@DisplayName("재시도 가능한 ErrorCode 들에 대한 메시지들을 반환한다")
+	@Test
+	void getRetryableMessages() {
+		List<Message> retryableMessages = result.getRetryableMessages();
+
+		assertThat(retryableMessages).hasSize(3);
+	}
+
+	@DisplayName("재시도 불가능한 ErrorCode 들에 대한 메시지들을 반환한다")
+	@Test
+	void getNonRetryableMessages() {
+		List<Message> retryableMessages = result.getNonRetryableMessages();
+
+		assertThat(retryableMessages).hasSize(4);
+	}
+
+	@DisplayName("재시도 가능한 ErrorCode 를 포함하고 있으면 true 를 반환한다")
+	@Test
+	void hasRetryableFailure_true() {
+		boolean actual = result.hasRetryableFailure();
+
+		assertThat(actual).isTrue();
+	}
+
+
+	@DisplayName("재시도 가능한 ErrorCode 를 포함하고 있지 않으면 false 를 반환한다")
+	@Test
+	void hasRetryableFailure_false() {
+		NotificationResult givenResult = new NotificationResult(Map.of(
+			Message.builder().setToken("test").build(), MessagingErrorCode.THIRD_PARTY_AUTH_ERROR,
+			Message.builder().setToken("test").build(), MessagingErrorCode.INVALID_ARGUMENT,
+			Message.builder().setToken("test").build(), MessagingErrorCode.SENDER_ID_MISMATCH,
+			Message.builder().setToken("test").build(), MessagingErrorCode.UNREGISTERED
+		));
+		boolean actual = givenResult.hasRetryableFailure();
+
+		assertThat(actual).isFalse();
+	}
+}


### PR DESCRIPTION
## 주요 개선 사항
- batch 애플리케이션 실행 시, 함께 실행되어 리소스를 잡아먹던(`while(true)`) `RetryWorker` 스레드 분리
- 실패 메시지 발생 시에만 생성되어 수행되도록 변경
- `NotificationResult` : 알림 전송 결과를 매핑하여, 재시도 가능한 메시지와 재시도 불가능한 메시지 구분
  - 로직 세분화 가능

