### PR TITLE
feature: 버전 정보 endpoint 추가

### DIFF
--- a/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckApiSpecComposer.java
+++ b/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckApiSpecComposer.java
@@ -1,0 +1,22 @@
+package com.barlow.app.api.controller.v1.version;
+
+import com.barlow.core.enumerate.ClientVersionStatus;
+
+public class ClientVersionCheckApiSpecComposer {
+
+    private final ClientVersionStatus clientVersionStatus;
+
+    public ClientVersionCheckApiSpecComposer(ClientVersionStatus clientVersionStatus) {
+        this.clientVersionStatus = clientVersionStatus;
+    }
+
+    ClientVersionCheckResponse compose() {
+        if(clientVersionStatus.equals(ClientVersionStatus.LATEST)) {
+            return new ClientVersionCheckResponse(false, false);
+        }
+        if(clientVersionStatus.equals(ClientVersionStatus.UPDATE_AVAILABLE)) {
+            return new ClientVersionCheckResponse(false, true);
+        }
+        return new ClientVersionCheckResponse(true, true);
+    }
+}

--- a/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckApiSpecComposer.java
+++ b/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckApiSpecComposer.java
@@ -4,19 +4,19 @@ import com.barlow.core.enumerate.ClientVersionStatus;
 
 public class ClientVersionCheckApiSpecComposer {
 
-    private final ClientVersionStatus clientVersionStatus;
+	private final ClientVersionStatus clientVersionStatus;
 
-    public ClientVersionCheckApiSpecComposer(ClientVersionStatus clientVersionStatus) {
-        this.clientVersionStatus = clientVersionStatus;
-    }
+	public ClientVersionCheckApiSpecComposer(ClientVersionStatus clientVersionStatus) {
+		this.clientVersionStatus = clientVersionStatus;
+	}
 
-    ClientVersionCheckResponse compose() {
-        if(clientVersionStatus.equals(ClientVersionStatus.LATEST)) {
-            return new ClientVersionCheckResponse(false, false);
-        }
-        if(clientVersionStatus.equals(ClientVersionStatus.UPDATE_AVAILABLE)) {
-            return new ClientVersionCheckResponse(false, true);
-        }
-        return new ClientVersionCheckResponse(true, true);
-    }
+	ClientVersionCheckResponse compose() {
+		if (clientVersionStatus.equals(ClientVersionStatus.LATEST)) {
+			return new ClientVersionCheckResponse(false, false);
+		}
+		if (clientVersionStatus.equals(ClientVersionStatus.UPDATE_AVAILABLE)) {
+			return new ClientVersionCheckResponse(false, true);
+		}
+		return new ClientVersionCheckResponse(true, true);
+	}
 }

--- a/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckController.java
+++ b/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckController.java
@@ -5,6 +5,7 @@ import com.barlow.core.domain.version.ClientVersionQuery;
 import com.barlow.core.domain.version.ClientVersionService;
 import com.barlow.core.enumerate.ClientVersionStatus;
 import com.barlow.core.enumerate.DeviceOs;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,19 +15,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/client-version")
 public class ClientVersionCheckController {
 
-    private final ClientVersionService clientVersionService;
+	private final ClientVersionService clientVersionService;
 
-    public ClientVersionCheckController(ClientVersionService clientVersionService) {
-        this.clientVersionService = clientVersionService;
-    }
+	public ClientVersionCheckController(ClientVersionService clientVersionService) {
+		this.clientVersionService = clientVersionService;
+	}
 
-    @GetMapping("/check")
-    public ApiResponse<ClientVersionCheckResponse> retrieveVersionCheckResponse(
-            @RequestHeader("X-App-Version") String appVersion,
-            @RequestHeader("X-Device-Os") String deviceOs
-    ) {
-        ClientVersionStatus status = clientVersionService.checkClientVersion(new ClientVersionQuery(DeviceOs.valueOf(deviceOs),appVersion));
-        ClientVersionCheckApiSpecComposer composer = new ClientVersionCheckApiSpecComposer(status);
-        return ApiResponse.success(composer.compose());
-    }
+	@GetMapping("/check")
+	public ApiResponse<ClientVersionCheckResponse> retrieveVersionCheckResponse(
+		@RequestHeader("X-App-Version") String appVersion,
+		@RequestHeader("X-Device-Os") String deviceOs
+	) {
+		ClientVersionStatus status = clientVersionService.checkClientVersion(
+			new ClientVersionQuery(DeviceOs.valueOf(deviceOs), appVersion)
+		);
+		ClientVersionCheckApiSpecComposer composer = new ClientVersionCheckApiSpecComposer(status);
+		return ApiResponse.success(composer.compose());
+	}
 }

--- a/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckController.java
+++ b/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckController.java
@@ -1,0 +1,32 @@
+package com.barlow.app.api.controller.v1.version;
+
+import com.barlow.app.support.response.ApiResponse;
+import com.barlow.core.domain.version.ClientVersionQuery;
+import com.barlow.core.domain.version.ClientVersionService;
+import com.barlow.core.enumerate.ClientVersionStatus;
+import com.barlow.core.enumerate.DeviceOs;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/client-version")
+public class ClientVersionCheckController {
+
+    private final ClientVersionService clientVersionService;
+
+    public ClientVersionCheckController(ClientVersionService clientVersionService) {
+        this.clientVersionService = clientVersionService;
+    }
+
+    @GetMapping("/check")
+    public ApiResponse<ClientVersionCheckResponse> retrieveVersionCheckResponse(
+            @RequestHeader("X-App-Version") String appVersion,
+            @RequestHeader("X-Device-Os") String deviceOs
+    ) {
+        ClientVersionStatus status = clientVersionService.checkClientVersion(new ClientVersionQuery(DeviceOs.valueOf(deviceOs),appVersion));
+        ClientVersionCheckApiSpecComposer composer = new ClientVersionCheckApiSpecComposer(status);
+        return ApiResponse.success(composer.compose());
+    }
+}

--- a/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckResponse.java
+++ b/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckResponse.java
@@ -1,7 +1,7 @@
 package com.barlow.app.api.controller.v1.version;
 
 public record ClientVersionCheckResponse(
-        boolean needForceUpdate,
-        boolean updateAvailable
+	boolean needForceUpdate,
+	boolean updateAvailable
 ) {
 }

--- a/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckResponse.java
+++ b/app/api/src/main/java/com/barlow/app/api/controller/v1/version/ClientVersionCheckResponse.java
@@ -1,0 +1,7 @@
+package com.barlow.app.api.controller.v1.version;
+
+public record ClientVersionCheckResponse(
+        boolean needForceUpdate,
+        boolean updateAvailable
+) {
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/AllowOnlyOfficialReleaseStrategy.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/AllowOnlyOfficialReleaseStrategy.java
@@ -1,0 +1,20 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.ClientVersionStatus;
+
+public class AllowOnlyOfficialReleaseStrategy implements ClientVersionUpdateStrategy{
+
+    @Override
+    public ClientVersionStatus evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion) {
+        if(clientVersion.isOfficialRelease()) {
+            return ClientVersionStatus.INVALID;
+        }
+        if(clientVersion.isLessThan(availableClientVersion.minimumClientVersion())) {
+            return ClientVersionStatus.NEED_FORCE_UPDATE;
+        }
+        if(clientVersion.isLessThan(availableClientVersion.latestClientVersion())) {
+            return ClientVersionStatus.UPDATE_AVAILABLE;
+        }
+        return ClientVersionStatus.LATEST;
+    }
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/AllowOnlyOfficialReleaseStrategy.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/AllowOnlyOfficialReleaseStrategy.java
@@ -2,19 +2,19 @@ package com.barlow.core.domain.version;
 
 import com.barlow.core.enumerate.ClientVersionStatus;
 
-public class AllowOnlyOfficialReleaseStrategy implements ClientVersionUpdateStrategy{
+public class AllowOnlyOfficialReleaseStrategy implements ClientVersionUpdateStrategy {
 
-    @Override
-    public ClientVersionStatus evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion) {
-        if(clientVersion.isOfficialRelease()) {
-            return ClientVersionStatus.INVALID;
-        }
-        if(clientVersion.isLessThan(availableClientVersion.minimumClientVersion())) {
-            return ClientVersionStatus.NEED_FORCE_UPDATE;
-        }
-        if(clientVersion.isLessThan(availableClientVersion.latestClientVersion())) {
-            return ClientVersionStatus.UPDATE_AVAILABLE;
-        }
-        return ClientVersionStatus.LATEST;
-    }
+	@Override
+	public ClientVersionStatus evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion) {
+		if (clientVersion.isOfficialRelease()) {
+			return ClientVersionStatus.INVALID;
+		}
+		if (clientVersion.isLessThan(availableClientVersion.minimumClientVersion())) {
+			return ClientVersionStatus.NEED_FORCE_UPDATE;
+		}
+		if (clientVersion.isLessThan(availableClientVersion.latestClientVersion())) {
+			return ClientVersionStatus.UPDATE_AVAILABLE;
+		}
+		return ClientVersionStatus.LATEST;
+	}
 }

--- a/core/domain/src/main/java/com/barlow/core/domain/version/AllowUnofficialReleaseStrategy.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/AllowUnofficialReleaseStrategy.java
@@ -1,0 +1,21 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.ClientVersionStatus;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Profile({"dev, local-dev, local, test, live"})
+@Component
+public class AllowUnofficialReleaseStrategy implements ClientVersionUpdateStrategy{
+
+    @Override
+    public ClientVersionStatus evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion) {
+        if(clientVersion.isLessThan(availableClientVersion.minimumClientVersion())) {
+            return ClientVersionStatus.NEED_FORCE_UPDATE;
+        }
+        if(clientVersion.isLessThan(availableClientVersion.latestClientVersion())) {
+            return ClientVersionStatus.UPDATE_AVAILABLE;
+        }
+        return ClientVersionStatus.LATEST;
+    }
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/AvailableClientVersion.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/AvailableClientVersion.java
@@ -1,6 +1,7 @@
 package com.barlow.core.domain.version;
 
-public record AvailableClientVersion (
-    SemanticVersion minimumClientVersion,
-    SemanticVersion latestClientVersion){
+public record AvailableClientVersion(
+	SemanticVersion minimumClientVersion,
+	SemanticVersion latestClientVersion
+) {
 }

--- a/core/domain/src/main/java/com/barlow/core/domain/version/AvailableClientVersion.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/AvailableClientVersion.java
@@ -1,0 +1,6 @@
+package com.barlow.core.domain.version;
+
+public record AvailableClientVersion (
+    SemanticVersion minimumClientVersion,
+    SemanticVersion latestClientVersion){
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionException.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionException.java
@@ -1,0 +1,16 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.exception.CoreDomainException;
+import com.barlow.core.exception.CoreDomainExceptionCode;
+import com.barlow.core.exception.CoreDomainExceptionLevel;
+
+public class ClientVersionException extends CoreDomainException {
+
+    ClientVersionException(CoreDomainExceptionCode code, CoreDomainExceptionLevel level, String message) {
+        super(code, level, message);
+    }
+
+    public static ClientVersionException invalidVersion(String message) {
+        return new ClientVersionException(CoreDomainExceptionCode.E400, CoreDomainExceptionLevel.IMPLEMENTATION, message);
+    }
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionQuery.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionQuery.java
@@ -1,0 +1,6 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.DeviceOs;
+
+public record ClientVersionQuery(DeviceOs deviceOs, String clientVersion) {
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionRepository.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionRepository.java
@@ -1,10 +1,10 @@
 package com.barlow.core.domain.version;
 
 import com.barlow.core.enumerate.DeviceOs;
+
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClientVersionRepository {
-
-    AvailableClientVersion retrieveByDeviceOs(DeviceOs deviceOs);
+	AvailableClientVersion retrieveByDeviceOs(DeviceOs deviceOs);
 }

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionRepository.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionRepository.java
@@ -1,0 +1,10 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.DeviceOs;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClientVersionRepository {
+
+    AvailableClientVersion retrieveByDeviceOs(DeviceOs deviceOs);
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionService.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionService.java
@@ -1,0 +1,22 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.ClientVersionStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ClientVersionService {
+
+    private final ClientVersionRepository clientVersionRepository;
+    private final ClientVersionUpdateStrategy clientVersionUpdateStrategy;
+
+    public ClientVersionService(ClientVersionRepository clientVersionRepository, ClientVersionUpdateStrategy clientVersionUpdateStrategy) {
+        this.clientVersionRepository = clientVersionRepository;
+        this.clientVersionUpdateStrategy = clientVersionUpdateStrategy;
+    }
+
+    public ClientVersionStatus checkClientVersion(ClientVersionQuery query) {
+        SemanticVersion targetClientVersion = SemanticVersion.of(query.clientVersion());
+        AvailableClientVersion currentAvailableVersion = clientVersionRepository.retrieveByDeviceOs(query.deviceOs());
+        return clientVersionUpdateStrategy.evaluate(targetClientVersion, currentAvailableVersion);
+    }
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionService.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionService.java
@@ -1,22 +1,26 @@
 package com.barlow.core.domain.version;
 
 import com.barlow.core.enumerate.ClientVersionStatus;
+
 import org.springframework.stereotype.Service;
 
 @Service
 public class ClientVersionService {
 
-    private final ClientVersionRepository clientVersionRepository;
-    private final ClientVersionUpdateStrategy clientVersionUpdateStrategy;
+	private final ClientVersionRepository clientVersionRepository;
+	private final ClientVersionUpdateStrategy clientVersionUpdateStrategy;
 
-    public ClientVersionService(ClientVersionRepository clientVersionRepository, ClientVersionUpdateStrategy clientVersionUpdateStrategy) {
-        this.clientVersionRepository = clientVersionRepository;
-        this.clientVersionUpdateStrategy = clientVersionUpdateStrategy;
-    }
+	public ClientVersionService(
+		ClientVersionRepository clientVersionRepository,
+		ClientVersionUpdateStrategy clientVersionUpdateStrategy
+	) {
+		this.clientVersionRepository = clientVersionRepository;
+		this.clientVersionUpdateStrategy = clientVersionUpdateStrategy;
+	}
 
-    public ClientVersionStatus checkClientVersion(ClientVersionQuery query) {
-        SemanticVersion targetClientVersion = SemanticVersion.of(query.clientVersion());
-        AvailableClientVersion currentAvailableVersion = clientVersionRepository.retrieveByDeviceOs(query.deviceOs());
-        return clientVersionUpdateStrategy.evaluate(targetClientVersion, currentAvailableVersion);
-    }
+	public ClientVersionStatus checkClientVersion(ClientVersionQuery query) {
+		SemanticVersion targetClientVersion = SemanticVersion.of(query.clientVersion());
+		AvailableClientVersion currentAvailableVersion = clientVersionRepository.retrieveByDeviceOs(query.deviceOs());
+		return clientVersionUpdateStrategy.evaluate(targetClientVersion, currentAvailableVersion);
+	}
 }

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionUpdateStrategy.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionUpdateStrategy.java
@@ -1,0 +1,7 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.ClientVersionStatus;
+
+public interface ClientVersionUpdateStrategy {
+    ClientVersionStatus evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion);
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionUpdateStrategy.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/ClientVersionUpdateStrategy.java
@@ -3,5 +3,5 @@ package com.barlow.core.domain.version;
 import com.barlow.core.enumerate.ClientVersionStatus;
 
 public interface ClientVersionUpdateStrategy {
-    ClientVersionStatus evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion);
+	ClientVersionStatus evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion);
 }

--- a/core/domain/src/main/java/com/barlow/core/domain/version/SemanticVersion.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/SemanticVersion.java
@@ -1,0 +1,64 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.VersionSuffix;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public final class SemanticVersion {
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9]+)?$");
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final VersionSuffix versionSuffix;
+
+    public SemanticVersion(int major, int minor, int patch, VersionSuffix versionSuffix) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        this.versionSuffix = versionSuffix;
+    }
+
+    public static SemanticVersion of(String versionValue) {
+        if(!VERSION_PATTERN.matcher(versionValue).matches()) {
+            throw new IllegalArgumentException();
+        }
+        String[] parts = versionValue.split("[.-]");
+        int major = Integer.parseInt(parts[0]);
+        int minor = Integer.parseInt(parts[1]);
+        int patch = Integer.parseInt(parts[2]);
+        if(parts.length == 4) {
+            return new SemanticVersion(major, minor, patch, VersionSuffix.fromString(parts[3]));
+        }
+        return new SemanticVersion(major, minor, patch, VersionSuffix.NONE);
+    }
+
+    public boolean isLessThan(SemanticVersion other) {
+        return this.compareTo(other) < 0;
+    }
+
+    private int compareTo(SemanticVersion other) {
+        if (major != other.major) return Integer.compare(major, other.major);
+        if (minor != other.minor) return Integer.compare(minor, other.minor);
+        if (patch != other.patch) return Integer.compare(patch, other.patch);
+        return Integer.compare(versionSuffix.getPriority(), other.versionSuffix.getPriority());
+    }
+
+    public boolean isOfficialRelease() {
+        return versionSuffix == VersionSuffix.NONE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SemanticVersion that = (SemanticVersion) o;
+        return major == that.major && minor == that.minor && patch == that.patch && versionSuffix == that.versionSuffix;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, patch, versionSuffix);
+    }
+}

--- a/core/domain/src/main/java/com/barlow/core/domain/version/SemanticVersion.java
+++ b/core/domain/src/main/java/com/barlow/core/domain/version/SemanticVersion.java
@@ -22,7 +22,7 @@ public final class SemanticVersion {
 
     public static SemanticVersion of(String versionValue) {
         if(!VERSION_PATTERN.matcher(versionValue).matches()) {
-            throw new IllegalArgumentException();
+            throw ClientVersionException.invalidVersion("지원하지 않는 버전 이름입니다: " + versionValue);
         }
         String[] parts = versionValue.split("[.-]");
         int major = Integer.parseInt(parts[0]);

--- a/core/domain/src/main/java/com/barlow/core/enumerate/ClientVersionStatus.java
+++ b/core/domain/src/main/java/com/barlow/core/enumerate/ClientVersionStatus.java
@@ -1,0 +1,9 @@
+package com.barlow.core.enumerate;
+
+public enum ClientVersionStatus {
+    LATEST,
+    UPDATE_AVAILABLE,
+    NEED_FORCE_UPDATE,
+    INVALID
+    ;
+}

--- a/core/domain/src/main/java/com/barlow/core/enumerate/ClientVersionStatus.java
+++ b/core/domain/src/main/java/com/barlow/core/enumerate/ClientVersionStatus.java
@@ -1,9 +1,9 @@
 package com.barlow.core.enumerate;
 
 public enum ClientVersionStatus {
-    LATEST,
-    UPDATE_AVAILABLE,
-    NEED_FORCE_UPDATE,
-    INVALID
-    ;
+	LATEST,
+	UPDATE_AVAILABLE,
+	NEED_FORCE_UPDATE,
+	INVALID
+	;
 }

--- a/core/domain/src/main/java/com/barlow/core/enumerate/VersionSuffix.java
+++ b/core/domain/src/main/java/com/barlow/core/enumerate/VersionSuffix.java
@@ -1,0 +1,40 @@
+package com.barlow.core.enumerate;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public enum VersionSuffix {
+    SNAPSHOT(0, "snapshot"),
+    ALPHA(1, "alpha"),
+    BETA(2, "beta"),
+    RC(3, "rc"),
+    NONE(4, ""),
+    ;
+
+    private static final Map<String, VersionSuffix> MAP_BY_VERSION_NAME = Arrays.stream(values())
+            .collect(Collectors.toMap(v -> v.name, v -> v));
+
+    private final int priority;
+    private final String name;
+
+    VersionSuffix(int priority, String name) {
+        this.priority = priority;
+        this.name = name;
+    }
+
+    public static VersionSuffix fromString(String versionName) {
+        if (versionName == null || versionName.isBlank()) return NONE;
+        return Optional.ofNullable(MAP_BY_VERSION_NAME.get(versionName.toLowerCase()))
+                .orElseThrow(() -> new IllegalArgumentException("Unknown suffix: " + versionName));
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}

--- a/core/domain/src/test/java/com/barlow/core/domain/version/AllowUnofficialReleaseStrategyTest.java
+++ b/core/domain/src/test/java/com/barlow/core/domain/version/AllowUnofficialReleaseStrategyTest.java
@@ -1,0 +1,36 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.ClientVersionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AllowUnofficialReleaseStrategyTest {
+
+    @DisplayName("버전 정보에 따라 업데이트 여부를 반환하는지 확인")
+    @ParameterizedTest
+    @MethodSource("generateVersionData")
+    void evaluate(SemanticVersion clientVersion, AvailableClientVersion availableClientVersion,ClientVersionStatus expected) {
+        ClientVersionUpdateStrategy strategy = new AllowUnofficialReleaseStrategy();
+        ClientVersionStatus actual = strategy.evaluate(clientVersion, availableClientVersion);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateVersionData() {
+        AvailableClientVersion availableClientVersion = new AvailableClientVersion(
+                SemanticVersion.of("1.1.0"),
+                SemanticVersion.of("2.0.0")
+        );
+        return Stream.of(
+            Arguments.of(SemanticVersion.of("1.0.0-rc"), availableClientVersion, ClientVersionStatus.NEED_FORCE_UPDATE),
+            Arguments.of(SemanticVersion.of("1.0.0"), availableClientVersion, ClientVersionStatus.NEED_FORCE_UPDATE),
+            Arguments.of(SemanticVersion.of("2.0.0"), availableClientVersion, ClientVersionStatus.LATEST),
+            Arguments.of(SemanticVersion.of("1.1.0"), availableClientVersion, ClientVersionStatus.UPDATE_AVAILABLE)
+        );
+    }
+}

--- a/core/domain/src/test/java/com/barlow/core/domain/version/SemanticVersionTest.java
+++ b/core/domain/src/test/java/com/barlow/core/domain/version/SemanticVersionTest.java
@@ -1,0 +1,68 @@
+package com.barlow.core.domain.version;
+
+import com.barlow.core.enumerate.VersionSuffix;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SemanticVersionTest {
+
+    @DisplayName("semanticversion의 정규식을 통해 생성되는지 확인")
+    @ParameterizedTest
+    @MethodSource("generateSemanticData")
+    void testOf(String value, int major, int minor, int patch, VersionSuffix suffix) {
+        SemanticVersion actual = SemanticVersion.of(value);
+        SemanticVersion expected = new SemanticVersion(major, minor, patch, suffix);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateSemanticData() {
+        return Stream.of(
+            Arguments.of("1.0.0", 1, 0, 0, VersionSuffix.NONE),
+            Arguments.of("1.0.0-alpha", 1, 0, 0, VersionSuffix.ALPHA),
+            Arguments.of("1.0.0-beta", 1, 0, 0, VersionSuffix.BETA),
+            Arguments.of(("1.2.2-snapshot"), 1, 2, 2, VersionSuffix.SNAPSHOT),
+            Arguments.of(("3.10.3-rc"), 3, 10, 3, VersionSuffix.RC)
+        );
+    }
+
+    @DisplayName("sematicVersion의 suffix 간 하위 버전을 제대로 인식하는지 확인")
+    @ParameterizedTest
+    @MethodSource("generateSuffixCompareData")
+    void testSuffixIsLessThan(String left, String right, boolean expected) {
+        boolean actual = SemanticVersion.of(left).isLessThan(SemanticVersion.of(right));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateSuffixCompareData() {
+        return Stream.of(
+                Arguments.of("1.0.0-snapshot", "1.0.0-alpha", true),
+                Arguments.of("1.0.0-snapshot", "1.0.0-snapshot", false),
+                Arguments.of("1.0.0-alpha", "1.0.0-beta", true),
+                Arguments.of("1.0.0-beta", "1.0.0-rc", true),
+                Arguments.of("1.0.0-rc", "1.0.0", true)
+        );
+    }
+
+    @DisplayName("sematicVersion의 suffix 간 하위 버전을 제대로 인식하는지 확인")
+    @ParameterizedTest
+    @MethodSource("generateCompareData")
+    void isLessThan(String left, String right, boolean expected) {
+        boolean actual = SemanticVersion.of(left).isLessThan(SemanticVersion.of(right));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateCompareData() {
+        return Stream.of(
+                Arguments.of("1.0.0", "1.0.1", true),
+                Arguments.of("1.0.0", "1.0.0", false),
+                Arguments.of("1.0.1", "1.1.0", true),
+                Arguments.of("1.1.1", "2.1.0", true)
+        );
+    }
+}

--- a/core/storage/src/main/java/com/barlow/core/storage/ClientVersionJpaEntity.java
+++ b/core/storage/src/main/java/com/barlow/core/storage/ClientVersionJpaEntity.java
@@ -1,0 +1,33 @@
+package com.barlow.core.storage;
+
+import com.barlow.core.domain.version.AvailableClientVersion;
+import com.barlow.core.domain.version.SemanticVersion;
+import com.barlow.core.enumerate.DeviceOs;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "client_version")
+public class ClientVersionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "no")
+    private Long no;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(10)", name = "device_os", nullable = false)
+    private DeviceOs deviceOs;
+
+    @Column(name = "minimum_supported", length = 50)
+    private String minimumSupported;
+
+    @Column(name = "latest", length = 50)
+    private String latest;
+
+    AvailableClientVersion toAvailableClientVersion() {
+        return new AvailableClientVersion(
+            SemanticVersion.of(minimumSupported),
+            SemanticVersion.of(latest)
+        );
+    }
+}

--- a/core/storage/src/main/java/com/barlow/core/storage/ClientVersionJpaEntity.java
+++ b/core/storage/src/main/java/com/barlow/core/storage/ClientVersionJpaEntity.java
@@ -3,31 +3,39 @@ package com.barlow.core.storage;
 import com.barlow.core.domain.version.AvailableClientVersion;
 import com.barlow.core.domain.version.SemanticVersion;
 import com.barlow.core.enumerate.DeviceOs;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "client_version")
 public class ClientVersionJpaEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "no")
-    private Long no;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "no")
+	private Long no;
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "varchar(10)", name = "device_os", nullable = false)
-    private DeviceOs deviceOs;
+	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "varchar(10)", name = "device_os", nullable = false)
+	private DeviceOs deviceOs;
 
-    @Column(name = "minimum_supported", length = 50)
-    private String minimumSupported;
+	@Column(name = "minimum_supported", nullable = false, length = 50)
+	private String minimumSupported;
 
-    @Column(name = "latest", length = 50)
-    private String latest;
+	@Column(name = "latest", nullable = false, length = 50)
+	private String latest;
 
-    AvailableClientVersion toAvailableClientVersion() {
-        return new AvailableClientVersion(
-            SemanticVersion.of(minimumSupported),
-            SemanticVersion.of(latest)
-        );
-    }
+	AvailableClientVersion toAvailableClientVersion() {
+		return new AvailableClientVersion(
+			SemanticVersion.of(minimumSupported),
+			SemanticVersion.of(latest)
+		);
+	}
 }

--- a/core/storage/src/main/java/com/barlow/core/storage/ClientVersionJpaRepository.java
+++ b/core/storage/src/main/java/com/barlow/core/storage/ClientVersionJpaRepository.java
@@ -1,0 +1,12 @@
+package com.barlow.core.storage;
+
+import com.barlow.core.enumerate.DeviceOs;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ClientVersionJpaRepository extends JpaRepository<ClientVersionJpaEntity, Long> {
+
+    @Query("SELECT d FROM ClientVersionJpaEntity d WHERE d.deviceOs = :deviceOs")
+    ClientVersionJpaEntity findByDeviceOs(@Param("deviceOs")DeviceOs deviceOs);
+}

--- a/core/storage/src/main/java/com/barlow/core/storage/ClientVersionRepositoryAdapter.java
+++ b/core/storage/src/main/java/com/barlow/core/storage/ClientVersionRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package com.barlow.core.storage;
+
+import com.barlow.core.domain.version.AvailableClientVersion;
+import com.barlow.core.domain.version.ClientVersionRepository;
+import com.barlow.core.enumerate.DeviceOs;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ClientVersionRepositoryAdapter implements ClientVersionRepository {
+
+    private final ClientVersionJpaRepository repository;
+    private final Map<DeviceOs, AvailableClientVersion> cache = new ConcurrentHashMap<>();
+
+    public ClientVersionRepositoryAdapter(ClientVersionJpaRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public AvailableClientVersion retrieveByDeviceOs(DeviceOs os) {
+        return cache.computeIfAbsent(os, this::loadFromDb);
+    }
+
+    private AvailableClientVersion loadFromDb(DeviceOs os) {
+        return repository.findByDeviceOs(os).toAvailableClientVersion();
+    }
+
+    public void refresh(DeviceOs os) {
+        cache.put(os, loadFromDb(os));
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+}

--- a/core/storage/src/main/java/com/barlow/core/storage/ClientVersionRepositoryAdapter.java
+++ b/core/storage/src/main/java/com/barlow/core/storage/ClientVersionRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.barlow.core.storage;
 import com.barlow.core.domain.version.AvailableClientVersion;
 import com.barlow.core.domain.version.ClientVersionRepository;
 import com.barlow.core.enumerate.DeviceOs;
+
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -11,27 +12,27 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class ClientVersionRepositoryAdapter implements ClientVersionRepository {
 
-    private final ClientVersionJpaRepository repository;
-    private final Map<DeviceOs, AvailableClientVersion> cache = new ConcurrentHashMap<>();
+	private final ClientVersionJpaRepository repository;
+	private final Map<DeviceOs, AvailableClientVersion> cache = new ConcurrentHashMap<>();
 
-    public ClientVersionRepositoryAdapter(ClientVersionJpaRepository repository) {
-        this.repository = repository;
-    }
+	public ClientVersionRepositoryAdapter(ClientVersionJpaRepository repository) {
+		this.repository = repository;
+	}
 
-    @Override
-    public AvailableClientVersion retrieveByDeviceOs(DeviceOs os) {
-        return cache.computeIfAbsent(os, this::loadFromDb);
-    }
+	@Override
+	public AvailableClientVersion retrieveByDeviceOs(DeviceOs os) {
+		return cache.computeIfAbsent(os, this::loadFromDb);
+	}
 
-    private AvailableClientVersion loadFromDb(DeviceOs os) {
-        return repository.findByDeviceOs(os).toAvailableClientVersion();
-    }
+	private AvailableClientVersion loadFromDb(DeviceOs os) {
+		return repository.findByDeviceOs(os).toAvailableClientVersion();
+	}
 
-    public void refresh(DeviceOs os) {
-        cache.put(os, loadFromDb(os));
-    }
+	public void refresh(DeviceOs os) {
+		cache.put(os, loadFromDb(os));
+	}
 
-    public void clear() {
-        cache.clear();
-    }
+	public void clear() {
+		cache.clear();
+	}
 }

--- a/core/storage/src/test/java/com/barlow/core/storage/ClientVersionRepositoryAdapterTest.java
+++ b/core/storage/src/test/java/com/barlow/core/storage/ClientVersionRepositoryAdapterTest.java
@@ -1,0 +1,24 @@
+package com.barlow.core.storage;
+
+import com.barlow.core.enumerate.DeviceOs;
+import com.barlow.core.storage.support.StorageTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@StorageTest("dummy/clientVersion.json")
+class ClientVersionRepositoryAdapterTest extends CoreDbContextTest{
+
+    private final ClientVersionRepositoryAdapter adapter;
+
+    ClientVersionRepositoryAdapterTest(ClientVersionRepositoryAdapter adapter) {
+        this.adapter = adapter;
+    }
+
+    @DisplayName("deviceOs에 따른 호환 버전을 조회하는지 확인")
+    @Test
+    void testRetrieveByDeviceOs() {
+        assertThat(adapter.retrieveByDeviceOs(DeviceOs.ANDROID)).isNotNull();
+    }
+}

--- a/core/storage/src/test/resources/dummy/clientVersion.json
+++ b/core/storage/src/test/resources/dummy/clientVersion.json
@@ -1,0 +1,9 @@
+{
+  "client_version": [
+    {
+      "device_os": "android",
+      "minimum_supported": "1.0.0-alpha",
+      "latest": "1.0.1"
+    }
+  ]
+}


### PR DESCRIPTION

barlow 의 앱(client) 의 버전은 SematicVersion을 기본으로 합니다
https://semver.org/ 

클라이언트의 버전 정보는 다음과 같이 저장됩니다
```
+----------------------+
|  client_version      |
+----------------------+
| PK  no               |
|     device_os        |
|     minimum_supported|
|     latest           |
+----------------------+

1 | ANDROID | 1.2.0 |  1.5.3
2 | IOS     |1.3.0 |  1.4.1
```
---

## 정식 릴리즈
정식 릴리즈는 ```<major>.<minor>.<patch>```의 형태를 따릅니다
예시) 1.0.0, 1.2.1, 1.14.9

## 비공식 릴리즈
비공식 릴리즈는 ```<major>.<minor>.<patch>-<suffix>```형태를 따릅니다
현재 지원되는 suffix는
- ```snapshot```
- ```alhpa```
- ```beta```
- ```rc``` (release candidate)

이며 우선순위는 ```snapshot```<```alpha```<```beta```<```rc```<```정식 릴리즈(suffix없음)``` 순 입니다
예시) 1.0.0-alpha, 1.2.1-rc

우선순위(priority)는 버전이 하위 버전인지 확인하는 데에 사용되며
SematicVersion.class의 isLessThan()에서 사용합니다
예를들어 ```1.0.0-alpha```는 ```1.0.0-beta, 1.0.0-rc, 1.0.0``` 보다 낮은 버전입니다.

## SematicVersion.class ##
버전표기는 SematicVersion.class를 통해 관리되며 정규식을 통해 버전의 표기법을 검사합니다.
isLessThan()을 통해 다른 SemanticVersion과의 하위 버전 여부를 판단합니다.

도메인 내에서 요청된 클라이언트 버전에 따른 상태는
-  LATEST (요청 client버전이 latest와 동일)
- UPDATE_AVAILABLE (minimum_supported <= client버전 < latest) 
-  NEED_FORCE_UPDATE ( client버전 < minimum_supported )
- INVALID ( 비공식 버전과 같이 임의적으로 차단된 버전 )

## Stratetgy ##
현재 기본적으로 비공식 릴리즈 버전을 모두 허용하는 AllowUnofficialReleaseStrategy을 사용하고 있으나 추후 운영 서버를 위해 비공식 릴리즈 버전을 차단하기 위해선 AllowOnlyIfficialReleaseStrategy에 @Profile()설정을 하면 됩니다.
AllowOnlyOfficalReleaseStrategy에서는 비공식 릴리즈 버전에 따른 상태를 INVALID로 반환합니다.

## 주의사항 ##
버전 정보가 db에 의해 관리되고 있고 버전표기법에 따른 예외처리는 domain에서 하고 있기에 버전 정보를 수정 할 시에 버전 표기 법에 따라 정확하게 넣어야 합니다.
현재 repositoryAdapter를 통해 초기에 불러온 버전 정보를 간단하게 캐싱해서 사용하고 있으나 추후 캐싱전략을 정확하게 구현하거나 다른 방법을 찾아볼 필요성도 있습니다.

## 엔드포인트 ##
api/v1/client-version/check를 통해 요청 클라이언트의 header중 X-Device-Os와 X-App-Version을 통해 현재 가능한 버전을 리턴합니다.
요청 응답은 
needForceUpdate(boolean)
isUpdateAvailable(boolean)
으로 구성되어있습니다.

## 추가 ##
현재 batch설정 파일이 없어 storage계층 테스트 코드를 돌려보지 못햇습니다. 확인이 필요합니다
현재 헤더의 X-App-Version을 통한 핸들러는 구현하지 않고 있으며 버전 확인은 api/v1/client-version/check를 통해서만 가능합니다
