### PR TITLE
k6 : 포화지점 테스트 (feat. 성능 개선)

### DIFF
--- a/k6/package.json
+++ b/k6/package.json
@@ -5,8 +5,11 @@
   "scripts": {
     "recentbill-thumbnail:load": "k6 run recentbill/thumbnail-load.test.js",
     "recentbill-detail:spike": "k6 run recentbill/detail-spike.test.js",
+    "recentbill:saturation": "k6 run recentbill/saturation.test.js",
+
     "scenarios:bill-home": "k6 run scenarios/bill-home.test.js",
     "scenarios:committee-profile": "k6 run scenarios/committee-profile.test.js",
+
     "legislationaccount-subscribe": "k6 run legislationaccount/account-subscribe.test.js"
   },
   "keywords": [],

--- a/k6/recentbill/saturation.test.js
+++ b/k6/recentbill/saturation.test.js
@@ -1,0 +1,80 @@
+import http from 'k6/http';
+import {check, group, sleep} from "k6";
+import {SharedArray} from "k6/data";
+
+export const options = {
+    stages: [
+        // { duration: '1m', target: 25 },
+        // { duration: '1m', target: 50 },
+        // { duration: '1m', target: 75 },
+        // { duration: '1m', target: 100 },
+        // { duration: '1m', target: 125 },
+        // { duration: '1m', target: 150 },
+        // { duration: '1m', target: 175 },
+        // { duration: '1m', target: 200 },
+        // { duration: '3m', target: 0 }, // 종료
+        { duration: '1m', target: 5 },
+        { duration: '1m', target: 10 },
+        { duration: '1m', target: 15 },
+        { duration: '1m', target: 20 },
+        { duration: '1m', target: 24 },
+        { duration: '1m', target: 26 },
+        { duration: '1m', target: 28 },
+        { duration: '1m', target: 30 },
+        { duration: '2m', target: 0 }, // 종료
+    ],
+    thresholds: {
+        http_req_duration: ['p(95)<500'],  // 응답 시간 95%가 500ms 이내
+        http_req_failed: ['rate<0.05'],    // 오류율 5% 이하 허용
+    }
+}
+
+// setup
+const [secret] = new SharedArray('secret', () => {
+    return [JSON.parse(open('../common-secret.json'))]
+});
+const BASE_URL = secret.baseUrl;
+const SLEEP_DURATION = 0.1;
+
+export default function () {
+    group("/api/v1/recent-bill/thumbnail", () => {
+        const params = {
+            headers: {
+                Authorization: `Bearer ${secret.token}`,
+                "Content-Type": "application/json",
+                Accept: "application/json",
+                "X-Client-OS": `${secret.clientOs}`,
+                "X-Client-OS-Version": `${secret.clientOsVersion}`,
+                "X-Device-ID": `${secret.deviceId}`,
+            }
+        }
+        const filters = {
+            page: "0",
+            size: "10",
+        }
+        if (Math.random() < 0.5) { // 50%
+            filters.legislationType = ["HOUSE_STEERING", "LEGISLATION_AND_JUDICIARY", "STRATEGY_AND_FINANCE", "NATIONAL_DEFENSE"][Math.floor(Math.random() * 4)];
+        }
+        if (Math.random() < 0.2) { // 20%
+            filters.progressStatus = ["COMMITTEE_RECEIVED", "PLENARY_SUBMITTED", "PLENARY_DECIDED", "PROMULGATED"][Math.floor(Math.random() * 4)];
+        }
+        if (Math.random() < 0.05) { // 5%
+            filters.proposerType = ["GOVERNMENT", "CHAIRMAN", "SPEAKER", "LAWMAKER"][Math.floor(Math.random() * 4)];
+        }
+        if (Math.random() < 0.7) { // 70%
+            filters.partyName = ["PEOPLE_POWER", "MINJOO", "PROGRESSIVE", "NEW_FUTURE"][Math.floor(Math.random() * 4)];
+        }
+        const query = buildQueryString(filters);
+        const url = `${BASE_URL}/api/v1/recent-bill/thumbnail?${query}`;
+
+        const res = http.get(url, params);
+        check(res, {"status is 200": (res) => res.status === 200});
+        sleep(SLEEP_DURATION);
+    })
+}
+
+function buildQueryString(params) {
+    return Object.entries(params)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join("&");
+}


### PR DESCRIPTION
## 성능 개선 기준 API
현재 서비스에서 가장 많은 조회를 담당하는 `/api/v1/recent-bill/thumbnail` 를 기준으로 test 및 성능 개선.

## VU 200 명 기준으로 부하 테스트
### 개선 전
- avg=5.92s min=88.29ms med=5.87s max=22.65s p(90)=10.56s p(95)=11.35s
- TPS : 16
- 총 요청 처리량 : 11048 개
- **connection usage time : 최대 500ms**
- **connection acquire time : 20ms → 최대 5s**

#### 최대 병목 지점 : DB Connection Pool 포화

- HikariCP의 **active connection = 10**, **idle = 0**, **pending = 186**이라는 사실은 **요청이 커넥션 풀에서 커넥션을 얻지 못해 기다리는 상태**임을 의미
- 이로 인해 `connection acquire time`이 20ms → 5s로 치솟고, 이는 전체 HTTP 요청 처리 시간에 큰 영향
- `connection usage time`도 증가했으므로, DB 자체의 처리 성능도 병목에 기여하고 있을 가능성이 있음

#### 개선 방법 : 쿼리 개선

- **커넥션 점유 시간 단축 = 전체 시스템 부하 감소**
    - 커넥션 풀의 핵심 병목 원인은 **커넥션을 오래 사용하는 것**
    - 즉, 쿼리 성능이 개선되면 connection usage time 이 짧아지고, 더 많은 요청이 동일한 pool size 내에서 처리됨.
    - 때문에 이전보다 Pending 되는 커넥션의 수 또한 완화될 것으로 예상됨
- **Tomcat 쓰레드도 DB 커넥션 대기 때문에 블로킹됨**
    - 요청 처리가 `DB I/O`에 블로킹되어 Tomcat 쓰레드가 대기 상태로 묶여 실질적인 처리 능력이 제한됨
    - 따라서 쿼리가 빨라지면 처리 또한 빨라져 thread 사용률도 최적화될 것으로 예상

### 개선 후
- avg=801.16ms min=13.4ms med=767.48ms max=4.64s p(90)=1.5s  p(95)=1.69s
- TPS : 125
- 총 요청 처리량 : 73125 개
- **connection usage time : 최대 76ms**
- **connection acquire time : 20ms → 최대 448ms**

#### 결과

| 항목               | 개선 전        | 개선 후        | 개선 효과             |
|--------------------|----------------|----------------|------------------------|
| 평균 응답시간(avg) | 5.92초         | 801ms          | 약 7.4배 개선         |
| 중앙값(median)     | 5.87초         | 767ms          | 약 7.6배 개선         |
| 최대 응답시간(max) | 22.65초        | 4.64초         | 약 4.9배 개선         |
| p(90)              | 10.56초        | 1.5초          | 약 7배 개선           |
| p(95)              | 11.35초        | 1.69초         | 약 6.7배 개선         |
| TPS                | 16             | 125            | 약 7.8배 향상         |
| 총 처리 요청 수    | 11,048건       | 73,125건       | 6.6배 증가            |
| 커넥션 사용 시간   | 최대 500ms     | 최대 76ms      | 약 6.5배 개선         |
| 커넥션 획득 시간   | 20ms~5초       | 20ms~448ms     | 최악의 경우 약 11배 개선 |


모든 지표에서 성능이 개선됨

#### 추가 테스트 사항
- 특정 시점 이후로는 TPS 가 정체되는 구간이 존재함
- 해당 지점을 `부하 한계점` 으로 잡고, 서비스가 허용하는 **최대 동시 허용 사용자 수** 를 파악

## 포화 지점 테스트

기존 200 VU 를 기준으로 테스트 했을때, TPS 가 더 이상 증가하지 않고 평탄해지는 부분이 존재함.
이는 **요청 시작 후 1분 가량 지난 이후**이며, k6 의 stages 옵션에 따르면 VU 가 대략 30명 가량 되는 순간임.

테스트 목표는 다음과 같음.

- 기준은 `2xx ms` 범위 내에서 대부분의 요청이 처리되도록.
- 최대 지연은 1s를 넘지 않도록.

위 두 조건을 만족하는 최대 VU 를 찾는 것.
이를 `최대 동시 요청 허용 사용자 수`로 칭함.


```javascript
export const options = {
    stages: [
        { duration: '1m', target: 25 },
        { duration: '1m', target: 50 },
    ],
    thresholds: {
        // ...
    }
}
```
이에 따라서, 30명을 기준으로 다시 부하 테스트 진행.

### 결과

- avg=106.34ms 
- min=12.74ms  
- med=74.86ms 
- max=962.32ms
- p(90)=233.71ms
- p(95)=325ms

90% 이상의 요청이 233.71ms 이하로, 대부분의 요청이 2xx ms 대에서 해결되었음.
최대 지연시간은 962.32ms 로 1s 를 넘지 않았음.

<img width="331" alt="스크린샷 2025-06-04 오후 5 33 45" src="https://github.com/user-attachments/assets/5f9740d7-7057-4fdb-b898-7b1f38f8f44a" />

- TPS 또한 평탄화 구간 없이 상승 이후 거의 바로 하강하는 모습을 확인할 수 있음.
- 최대 TPS 는 115 이고, 이때의 평균 요청 처리 시간이 129ms 임.

<img width="708" alt="스크린샷 2025-06-04 오후 5 33 59" src="https://github.com/user-attachments/assets/b5469515-39e2-4ea9-bdc3-a20f806490bd" />

- connection acquire time 이 23.3ms 로 아주 좋은 성능을 보여줌
- connection creation time 이 30ms, connection usage time 은 최대 68ms 로 아주 좋은 성능을 보임

위 결과를 통해 최대 허용 동시 사용자 수는 30명으로 정하고, 앞으로 테스트에서 30 VU 를 기준으로 함.
