### PR TITLE
batch: 알림 센터 7일 이상 알림 데이터 자동 삭제 배치 Job 추가

### DIFF
--- a/app/batch/build.gradle
+++ b/app/batch/build.gradle
@@ -36,6 +36,12 @@ tasks.register('copyResourcesConfig', Copy) {
 
 processResources.dependsOn('copyResourcesConfig')
 
+tasks.named('contextTest') {
+    systemProperty 'KNAL_OPEN_DATA_API_SERVICE_KEY', 'test-dummy-key'
+    systemProperty 'KNAL_OPEN_CONGRESS_API_SERVICE_KEY', 'test-dummy-key'
+    systemProperty 'SUPPORT_ALERT_SLACK_WEBHOOK_URL', 'https://hooks.slack.com/services/mock-test-url'
+}
+
 tasks.register('buildZip', Zip) {
     dependsOn('bootJar')
 

--- a/app/batch/src/main/java/com/barlow/app/batch/controller/CoreBatchController.java
+++ b/app/batch/src/main/java/com/barlow/app/batch/controller/CoreBatchController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.barlow.app.batch.notificationcenter.job.NotificationCenterCleanupBatchJobExecutor;
 import com.barlow.app.batch.preannounce.job.PreAnnounceBatchJobExecutor;
 import com.barlow.app.batch.recentbill.job.RecentBillBatchJobExecutor;
 import com.barlow.app.batch.tracebill.job.TrackingBillBatchJobExecutor;
@@ -19,13 +20,16 @@ public class CoreBatchController {
 	private final RecentBillBatchJobExecutor recentBillBatchJobExecutor;
 	private final PreAnnounceBatchJobExecutor preAnnounceBatchJobExecutor;
 	private final TrackingBillBatchJobExecutor trackingBillBatchJobExecutor;
+	private final NotificationCenterCleanupBatchJobExecutor notificationCenterCleanupBatchJobExecutor;
 
 	public CoreBatchController(RecentBillBatchJobExecutor recentBillBatchJobExecutor,
 		PreAnnounceBatchJobExecutor preAnnounceBatchJobExecutor,
-		TrackingBillBatchJobExecutor trackingBillBatchJobExecutor) {
+		TrackingBillBatchJobExecutor trackingBillBatchJobExecutor,
+		NotificationCenterCleanupBatchJobExecutor notificationCenterCleanupBatchJobExecutor) {
 		this.recentBillBatchJobExecutor = recentBillBatchJobExecutor;
 		this.preAnnounceBatchJobExecutor = preAnnounceBatchJobExecutor;
 		this.trackingBillBatchJobExecutor = trackingBillBatchJobExecutor;
+		this.notificationCenterCleanupBatchJobExecutor = notificationCenterCleanupBatchJobExecutor;
 	}
 
 	@PostMapping("/pre-announcement-bill-job")
@@ -44,5 +48,11 @@ public class CoreBatchController {
 	public ResponseEntity<Void> executeTodayBatchJob() {
 		recentBillBatchJobExecutor.execute(LocalDate.now());
 		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/notification-center/cleanup")
+	public ResponseEntity<Void> triggerNotificationCenterCleanup() {
+		notificationCenterCleanupBatchJobExecutor.execute();
+		return ResponseEntity.ok().build();
 	}
 }

--- a/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/NotificationCenterConstant.java
+++ b/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/NotificationCenterConstant.java
@@ -1,0 +1,9 @@
+package com.barlow.app.batch.notificationcenter;
+
+public final class NotificationCenterConstant {
+
+	private NotificationCenterConstant() {}
+
+	public static final String JOB_NAME = "notificationCenterCleanupBatchJob";
+	public static final String STEP_NAME = "notificationCenterCleanupStep";
+}

--- a/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterCleanupBatchJobExecutor.java
+++ b/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterCleanupBatchJobExecutor.java
@@ -1,0 +1,45 @@
+package com.barlow.app.batch.notificationcenter.job;
+
+import static com.barlow.app.batch.notificationcenter.NotificationCenterConstant.JOB_NAME;
+
+import java.time.LocalDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import com.barlow.support.alert.Alerter;
+
+@Component
+public class NotificationCenterCleanupBatchJobExecutor {
+
+	private static final Logger log = LoggerFactory.getLogger(NotificationCenterCleanupBatchJobExecutor.class);
+
+	private final JobLauncher jobLauncher;
+	private final Job notificationCenterCleanupBatchJob;
+	private final Alerter alerter;
+
+	public NotificationCenterCleanupBatchJobExecutor(JobLauncher jobLauncher,
+		@Qualifier(JOB_NAME) Job notificationCenterCleanupBatchJob, Alerter alerter) {
+		this.jobLauncher = jobLauncher;
+		this.notificationCenterCleanupBatchJob = notificationCenterCleanupBatchJob;
+		this.alerter = alerter;
+	}
+
+	public void execute() {
+		try {
+			JobParameters params = new JobParametersBuilder().addLocalDateTime("executedAt", LocalDateTime.now())
+				.toJobParameters();
+			jobLauncher.run(notificationCenterCleanupBatchJob, params);
+		} catch (Exception e) {
+			alerter.alert("[NotificationCenter Cleanup Batch] 실행 실패: " + e.getMessage());
+			log.error("NotificationCenter Cleanup Batch 실패: {}", e.getMessage(), e);
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterItemBatchRepository.java
+++ b/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterItemBatchRepository.java
@@ -1,0 +1,7 @@
+package com.barlow.app.batch.notificationcenter.job;
+
+import java.time.LocalDateTime;
+
+public interface NotificationCenterItemBatchRepository {
+	int deleteOlderThan(LocalDateTime threshold, int limit);
+}

--- a/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/config/NotificationCenterCleanupBatchJobConfig.java
+++ b/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/config/NotificationCenterCleanupBatchJobConfig.java
@@ -1,0 +1,45 @@
+package com.barlow.app.batch.notificationcenter.job.config;
+
+import static com.barlow.app.batch.notificationcenter.NotificationCenterConstant.JOB_NAME;
+import static com.barlow.app.batch.notificationcenter.NotificationCenterConstant.STEP_NAME;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.barlow.app.batch.common.StepLoggingListener;
+import com.barlow.app.batch.notificationcenter.job.step.NotificationCenterCleanupTasklet;
+
+@Configuration
+public class NotificationCenterCleanupBatchJobConfig {
+
+	private final JobRepository jobRepository;
+	private final StepLoggingListener stepLoggingListener;
+
+	public NotificationCenterCleanupBatchJobConfig(
+		@Qualifier("batchCoreJobRepository") JobRepository jobRepository,
+		StepLoggingListener stepLoggingListener) {
+		this.jobRepository = jobRepository;
+		this.stepLoggingListener = stepLoggingListener;
+	}
+
+	@Bean(JOB_NAME)
+	public Job notificationCenterCleanupBatchJob(Step notificationCenterCleanupStep) {
+		return new JobBuilder(JOB_NAME, jobRepository).start(notificationCenterCleanupStep).build();
+	}
+
+	@Bean
+	@JobScope
+	public Step notificationCenterCleanupStep(NotificationCenterCleanupTasklet tasklet,
+		@Qualifier("batchCoreTransactionManager") PlatformTransactionManager transactionManager) {
+		return new StepBuilder(STEP_NAME, jobRepository).tasklet(tasklet, transactionManager)
+			.listener(stepLoggingListener).build();
+	}
+}

--- a/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/step/NotificationCenterCleanupTasklet.java
+++ b/app/batch/src/main/java/com/barlow/app/batch/notificationcenter/job/step/NotificationCenterCleanupTasklet.java
@@ -1,0 +1,44 @@
+package com.barlow.app.batch.notificationcenter.job.step;
+
+import java.time.LocalDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+import com.barlow.app.batch.notificationcenter.job.NotificationCenterItemBatchRepository;
+
+@Component
+@StepScope
+public class NotificationCenterCleanupTasklet implements Tasklet {
+
+	private static final Logger log = LoggerFactory.getLogger(NotificationCenterCleanupTasklet.class);
+
+	private static final int BATCH_SIZE = 1_000;
+	private static final int RETENTION_DAYS = 7;
+
+	private final NotificationCenterItemBatchRepository notificationCenterItemBatchRepository;
+
+	public NotificationCenterCleanupTasklet(
+		NotificationCenterItemBatchRepository notificationCenterItemBatchRepository) {
+		this.notificationCenterItemBatchRepository = notificationCenterItemBatchRepository;
+	}
+
+	@Override
+	public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+		LocalDateTime threshold = LocalDateTime.now().minusDays(RETENTION_DAYS);
+		int totalDeleted = 0;
+		int deleted;
+		do {
+			deleted = notificationCenterItemBatchRepository.deleteOlderThan(threshold, BATCH_SIZE);
+			totalDeleted += deleted;
+		} while (deleted == BATCH_SIZE);
+		log.info("NotificationCenter cleanup 완료 - 삭제된 항목 수: {}", totalDeleted);
+		return RepeatStatus.FINISHED;
+	}
+}

--- a/app/batch/src/main/java/com/barlow/infra/storage/batch/NotificationCenterItemBatchJpaRepository.java
+++ b/app/batch/src/main/java/com/barlow/infra/storage/batch/NotificationCenterItemBatchJpaRepository.java
@@ -1,0 +1,21 @@
+package com.barlow.infra.storage.batch;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.barlow.infra.storage.NotificationCenterItemJpaEntity;
+
+public interface NotificationCenterItemBatchJpaRepository
+	extends JpaRepository<NotificationCenterItemJpaEntity, Long> {
+
+	@Query("SELECT e.no FROM NotificationCenterItemJpaEntity e WHERE e.createdAt < :threshold")
+	List<Long> findIdsByCreatedAtBefore(@Param("threshold") LocalDateTime threshold, Pageable pageable);
+
+	@Query("SELECT COUNT(e) FROM NotificationCenterItemJpaEntity e WHERE e.createdAt < :threshold")
+	long countByCreatedAtBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/app/batch/src/main/java/com/barlow/infra/storage/batch/NotificationCenterItemBatchRepositoryAdapter.java
+++ b/app/batch/src/main/java/com/barlow/infra/storage/batch/NotificationCenterItemBatchRepositoryAdapter.java
@@ -1,0 +1,33 @@
+package com.barlow.infra.storage.batch;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.barlow.app.batch.notificationcenter.job.NotificationCenterItemBatchRepository;
+
+@Component
+public class NotificationCenterItemBatchRepositoryAdapter implements NotificationCenterItemBatchRepository {
+
+	private final NotificationCenterItemBatchJpaRepository notificationCenterItemBatchJpaRepository;
+
+	public NotificationCenterItemBatchRepositoryAdapter(
+		NotificationCenterItemBatchJpaRepository notificationCenterItemBatchJpaRepository) {
+		this.notificationCenterItemBatchJpaRepository = notificationCenterItemBatchJpaRepository;
+	}
+
+	@Override
+	@Transactional
+	public int deleteOlderThan(LocalDateTime threshold, int limit) {
+		List<Long> ids = notificationCenterItemBatchJpaRepository.findIdsByCreatedAtBefore(threshold,
+			PageRequest.of(0, limit));
+		if (ids.isEmpty()) {
+			return 0;
+		}
+		notificationCenterItemBatchJpaRepository.deleteAllByIdInBatch(ids);
+		return ids.size();
+	}
+}

--- a/app/batch/src/main/java/com/barlow/infra/storage/batch/config/BatchCoreJpaConfig.java
+++ b/app/batch/src/main/java/com/barlow/infra/storage/batch/config/BatchCoreJpaConfig.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import com.barlow.infra.storage.BillPostJpaEntity;
 import com.barlow.infra.storage.LegislationAccountJpaEntity;
+import com.barlow.infra.storage.NotificationCenterItemJpaEntity;
 import com.barlow.infra.storage.NotificationConfigJpaEntity;
 
 import jakarta.persistence.EntityManagerFactory;
@@ -27,7 +28,7 @@ import jakarta.persistence.EntityManagerFactory;
 @Configuration
 @EnableTransactionManagement
 @EntityScan(basePackageClasses = {BillPostJpaEntity.class, LegislationAccountJpaEntity.class,
-	NotificationConfigJpaEntity.class})
+	NotificationConfigJpaEntity.class, NotificationCenterItemJpaEntity.class})
 @EnableJpaRepositories(basePackages = {"com.barlow.infra.storage.batch",
 	"com.barlow.infra.storage.notification"}, entityManagerFactoryRef = "batchCoreEntityManagerFactory", transactionManagerRef = "batchCoreTransactionManager")
 public class BatchCoreJpaConfig {
@@ -44,7 +45,8 @@ public class BatchCoreJpaConfig {
 		EntityManagerFactoryBuilder builder) {
 		return builder.dataSource(dataSource)
 			.packages("com.barlow.infra.storage.batch", "com.barlow.infra.storage.notification")
-			.packages(BillPostJpaEntity.class, LegislationAccountJpaEntity.class, NotificationConfigJpaEntity.class)
+			.packages(BillPostJpaEntity.class, LegislationAccountJpaEntity.class, NotificationConfigJpaEntity.class,
+				NotificationCenterItemJpaEntity.class)
 			.persistenceUnit("batch-core").properties(jpaProperties.properties).build();
 	}
 

--- a/app/batch/src/test/java/com/barlow/app/batch/BatchCoreTestApplication.java
+++ b/app/batch/src/test/java/com/barlow/app/batch/BatchCoreTestApplication.java
@@ -1,14 +1,37 @@
 package com.barlow.app.batch;
 
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import com.barlow.infra.storage.batch.config.BatchCoreDatasourceConfig;
+import com.barlow.infra.storage.batch.config.BatchCoreJpaConfig;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@Import({BatchCoreDatasourceConfig.class, BatchCoreJpaConfig.class})
 public class BatchCoreTestApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(BatchCoreTestApplication.class, args);
+	}
+
+	@Bean
+	public DataSourceInitializer batchSchemaInitializer(@Qualifier("batchCoreDataSource") DataSource dataSource) {
+		ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+		populator.addScript(new ClassPathResource("org/springframework/batch/core/schema-h2.sql"));
+		populator.setContinueOnError(true);
+		DataSourceInitializer initializer = new DataSourceInitializer();
+		initializer.setDataSource(dataSource);
+		initializer.setDatabasePopulator(populator);
+		return initializer;
 	}
 }

--- a/app/batch/src/test/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterCleanupBatchJobExecutorTest.java
+++ b/app/batch/src/test/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterCleanupBatchJobExecutorTest.java
@@ -1,0 +1,55 @@
+package com.barlow.app.batch.notificationcenter.job;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.barlow.app.batch.BatchCoreContextTest;
+import com.barlow.app.batch.BatchCoreTestApplication;
+import com.barlow.app.batch.notificationcenter.NotificationCenterConstant;
+import com.barlow.support.alert.Alerter;
+
+@SpringBootTest(classes = BatchCoreTestApplication.class)
+class NotificationCenterCleanupBatchJobExecutorTest extends BatchCoreContextTest {
+
+	@Autowired
+	private NotificationCenterCleanupBatchJobExecutor notificationCenterCleanupBatchJobExecutor;
+
+	@MockBean
+	private JobLauncher jobLauncher;
+
+	@MockBean
+	private Alerter alerter;
+
+	@Autowired
+	@Qualifier(NotificationCenterConstant.JOB_NAME)
+	private Job notificationCenterCleanupBatchJob;
+
+	@Test
+	@DisplayName("JobLauncher 예외 발생 시 Alerter.alert()가 호출되고 RuntimeException이 re-throw 된다.")
+	void notificationCenterCleanupJobExecutor_JobLauncherThrowsException_AlertsAndRethrows() throws Exception {
+		// given — JobLauncher가 예외를 던지도록 설정
+		given(jobLauncher.run(eq(notificationCenterCleanupBatchJob),
+			org.mockito.ArgumentMatchers.any(JobParameters.class)))
+			.willThrow(new RuntimeException("배치 실행 실패"));
+
+		// when & then — RuntimeException re-throw 검증
+		assertThatThrownBy(() -> notificationCenterCleanupBatchJobExecutor.execute())
+			.isInstanceOf(RuntimeException.class);
+
+		// then — Alerter.alert() 호출 검증
+		then(alerter).should().alert(anyString());
+	}
+}

--- a/app/batch/src/test/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterCleanupBatchJobTest.java
+++ b/app/batch/src/test/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterCleanupBatchJobTest.java
@@ -1,0 +1,103 @@
+package com.barlow.app.batch.notificationcenter.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.barlow.app.batch.BatchCoreContextTest;
+import com.barlow.app.batch.BatchCoreTestApplication;
+import com.barlow.app.batch.notificationcenter.NotificationCenterConstant;
+import com.barlow.support.alert.Alerter;
+
+@SpringBatchTest
+@SpringBootTest(classes = BatchCoreTestApplication.class)
+class NotificationCenterCleanupBatchJobTest extends BatchCoreContextTest {
+
+	@Autowired
+	private JobLauncherTestUtils jobLauncherTestUtils;
+
+	@Autowired
+	@Qualifier(NotificationCenterConstant.JOB_NAME)
+	private Job notificationCenterCleanupBatchJob;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@MockBean
+	private Alerter alerter;
+
+	@BeforeEach
+	void setUp() {
+		jobLauncherTestUtils.setJob(notificationCenterCleanupBatchJob);
+	}
+
+	@Test
+	@DisplayName("threshold 이전 알림 데이터가 2,500건 있으면 배치 실행 시 전체 삭제 후 COMPLETED 반환된다.")
+	void notificationCenterCleanupJob_2500OldItemsExist_DeletesAllAndCompletes() throws Exception {
+		// given — 7일 초과 데이터 2,500건 삽입
+		LocalDateTime oldDate = LocalDateTime.now().minusDays(8);
+		for (int i = 0; i < 2500; i++) {
+			jdbcTemplate.update(
+				"INSERT INTO notification_center_item "
+					+ "(member_no, bill_id, notification_topic, title, body, created_at, updated_at) "
+					+ "VALUES (?, ?, ?, ?, ?, ?, ?)",
+				1L, "BILL_ID_" + i, "RECEIPT", "title_" + i, "body_" + i, oldDate, oldDate);
+		}
+		int beforeCount = countOldItems(oldDate.plusSeconds(1));
+		assertThat(beforeCount).isEqualTo(2500);
+
+		// when — Job 실행
+		JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+
+		// then — ExitStatus 검증
+		assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+
+		// then — 7일 초과 데이터 전체 삭제 검증
+		int afterCount = countOldItems(LocalDateTime.now().minusDays(7));
+		assertThat(afterCount).isZero();
+	}
+
+	@Test
+	@DisplayName("삭제 대상 알림 데이터가 0건이면 배치 실행 시 삭제 없이 COMPLETED 반환된다.")
+	void notificationCenterCleanupJob_NoOldItemsExist_CompletesWithoutDeletion() throws Exception {
+		// given — 7일 이내 데이터만 존재 (삭제 대상 없음)
+		LocalDateTime recentDate = LocalDateTime.now().minusDays(3);
+		jdbcTemplate.update(
+			"INSERT INTO notification_center_item "
+				+ "(member_no, bill_id, notification_topic, title, body, created_at, updated_at) "
+				+ "VALUES (?, ?, ?, ?, ?, ?, ?)",
+			2L, "RECENT_BILL_001", "RECEIPT", "최근 알림", "내용", recentDate, recentDate);
+
+		// when — Job 실행
+		JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+
+		// then — ExitStatus 검증
+		assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+
+		// then — 7일 이내 데이터는 삭제되지 않음
+		int remainCount = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM notification_center_item WHERE member_no = ?",
+			Integer.class, 2L);
+		assertThat(remainCount).isEqualTo(1);
+	}
+
+	private int countOldItems(LocalDateTime threshold) {
+		return jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM notification_center_item WHERE created_at < ?",
+			Integer.class, threshold);
+	}
+}

--- a/app/batch/src/test/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterItemBatchRepositoryAdapterTest.java
+++ b/app/batch/src/test/java/com/barlow/app/batch/notificationcenter/job/NotificationCenterItemBatchRepositoryAdapterTest.java
@@ -1,0 +1,71 @@
+package com.barlow.app.batch.notificationcenter.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.barlow.app.batch.BatchCoreContextTest;
+import com.barlow.app.batch.BatchCoreTestApplication;
+import com.barlow.infra.storage.batch.NotificationCenterItemBatchRepositoryAdapter;
+import com.barlow.support.alert.Alerter;
+
+@SpringBootTest(classes = BatchCoreTestApplication.class)
+class NotificationCenterItemBatchRepositoryAdapterTest extends BatchCoreContextTest {
+
+	@Autowired
+	private NotificationCenterItemBatchRepositoryAdapter notificationCenterItemBatchRepositoryAdapter;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@MockBean
+	private Alerter alerter;
+
+	@Test
+	@DisplayName("limit 이하 건수가 threshold 이전에 존재하면 deleteOlderThan 호출 시 실제 삭제된 건수를 반환한다.")
+	void deleteOlderThan_LessThanLimitItemsExist_ReturnsActualDeletedCount() {
+		// given — threshold 이전 데이터 5건 삽입
+		LocalDateTime oldDate = LocalDateTime.now().minusDays(8);
+		int insertCount = 5;
+		for (int i = 0; i < insertCount; i++) {
+			jdbcTemplate.update(
+				"INSERT INTO notification_center_item "
+					+ "(member_no, bill_id, notification_topic, title, body, created_at, updated_at) "
+					+ "VALUES (?, ?, ?, ?, ?, ?, ?)",
+				10L + i, "BILL_REPO_" + i, "RECEIPT", "title_" + i, "body_" + i, oldDate, oldDate);
+		}
+		LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+
+		// when — limit(1,000)보다 적은 5건을 대상으로 삭제 실행
+		int deleted = notificationCenterItemBatchRepositoryAdapter.deleteOlderThan(threshold, 1000);
+
+		// then — 실제 삭제된 건수(5)가 반환되어야 한다
+		assertThat(deleted).isEqualTo(insertCount);
+
+		// then — DB에서도 해당 데이터가 삭제되었음을 검증
+		int remainCount = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM notification_center_item WHERE created_at < ?",
+			Integer.class, threshold);
+		assertThat(remainCount).isZero();
+	}
+
+	@Test
+	@DisplayName("threshold 이전 데이터가 없으면 deleteOlderThan 호출 시 0을 반환한다.")
+	void deleteOlderThan_NoItemsBeforeThreshold_ReturnsZero() {
+		// given — 삭제 대상 없음 (threshold 이후 데이터만 존재)
+		LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+
+		// when
+		int deleted = notificationCenterItemBatchRepositoryAdapter.deleteOlderThan(threshold, 1000);
+
+		// then
+		assertThat(deleted).isZero();
+	}
+}

--- a/app/batch/src/test/resources/application.yml
+++ b/app/batch/src/test/resources/application.yml
@@ -1,0 +1,48 @@
+spring:
+  application:
+    name: batch-core-test
+  profiles:
+    active: local-dev
+  config:
+    import:
+      - notification.yml
+      - client-knal-api.yml
+      - monitoring.yml
+      - alert.yml
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false
+  main:
+    banner-mode: off
+
+storage:
+  datasource:
+    batch-core:
+      driver-class-name: org.h2.Driver
+      url: jdbc:h2:mem:core;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+      username: sa
+
+spring.jpa:
+  open-in-view: false
+  properties:
+    hibernate:
+      format_sql: false
+      show_sql: false
+      hbm2ddl.auto: create
+
+file:
+  lawmaker-json: lawmaker/lawmaker-22.json
+
+knal:
+  open-data:
+    api:
+      service-key: test-dummy-key
+  open-congress:
+    api:
+      service-key: test-dummy-key
+
+alert:
+  slack:
+    webhook-url: https://hooks.slack.com/services/mock-test-url


### PR DESCRIPTION
## 개요

매일 새벽 배치 스케줄러를 통해 7일 이상 된 알림 센터 항목을 자동 삭제한다. 수백만 건을 1,000건 단위로 분할 처리하여 DB 락 부하를 최소화한다.

## 관련 이슈

- Closes #122

## 변경 유형

- [x] `feat` — 새 기능

## 변경 레이어

- [x] `infra:storage` — `NotificationCenterItemBatchJpaRepository`, `NotificationCenterItemBatchRepositoryAdapter` 신규 추가
- [x] `app:batch` — `NotificationCenterCleanupTasklet`, `NotificationCenterCleanupBatchJobConfig`, `NotificationCenterCleanupBatchJobExecutor` 신규 추가
- [x] `app:api` — `CoreBatchController` 클린업 트리거 엔드포인트 추가
- [x] `테스트` — 배치 Job 인수 테스트 5개 추가

## 테스트

```bash
./gradlew :app:batch:contextTest
# 5 tests, 5 passed
```

## 아키텍처 체크리스트

- [x] `core:domain` 에 Spring 어노테이션(`@Service`, `@Component` 등) 없음
- [x] `core:service` 에서 `infra:*` 직접 import 없음
- [x] 도메인 객체 상태 변경 시 새 인스턴스 반환 (setter 없음)
- [x] 새 예외는 `CoreDomainException` 또는 `CoreApiException` 하위 + static factory
- [x] AR 간 참조는 ID-only (`long` 타입)

## 리뷰 포커스

- `NotificationCenterItemBatchRepository` (Port 인터페이스)를 `app:batch` 모듈에 별도 정의해 `core:domain`의 `NotificationCenterItemRepository` 수정 없이 배치 전용 인터페이스 분리한 설계가 올바른지 확인 부탁드립니다.
- `@EnableBatchProcessing` 사용 시 Spring Boot 3.x에서 배치 스키마 auto-initialization이 비활성화되어 테스트용 `BatchSchemaInitializer` Bean을 `BatchCoreTestApplication`에 추가했습니다.