### PR TITLE
[FIX] PreviousBills dirtyCheck null-safe 비교 로직 적용 (#125)

### DIFF
--- a/app/batch/src/main/java/com/barlow/app/batch/tracebill/job/PreviousBills.java
+++ b/app/batch/src/main/java/com/barlow/app/batch/tracebill/job/PreviousBills.java
@@ -17,12 +17,14 @@ public class PreviousBills {
 
 	public UpdatedBills dirtyCheck(CurrentBillInfoResult current) {
 		Map<ProgressStatus, List<UpdatedBills.BillInfo>> map = new EnumMap<>(ProgressStatus.class);
-		values.stream().filter(previous -> !current.getStatusByBillId(previous.billId()).equals(previous.status()))
-			.forEach(
-				previous -> map
-					.computeIfAbsent(current.getStatusByBillId(previous.billId()), status -> new ArrayList<>())
-					.add(
-						new UpdatedBills.BillInfo(previous.billId(), previous.billName(), previous.legislationType())));
+		values.forEach(previous -> {
+			ProgressStatus currentStatus = current.getStatusByBillId(previous.billId());
+			if (currentStatus == null || currentStatus.equals(previous.status())) {
+				return;
+			}
+			map.computeIfAbsent(currentStatus, status -> new ArrayList<>())
+				.add(new UpdatedBills.BillInfo(previous.billId(), previous.billName(), previous.legislationType()));
+		});
 		return new UpdatedBills(map);
 	}
 }

--- a/app/batch/src/test/java/com/barlow/app/batch/tracebill/job/PreviousBillsTest.java
+++ b/app/batch/src/test/java/com/barlow/app/batch/tracebill/job/PreviousBillsTest.java
@@ -1,0 +1,94 @@
+package com.barlow.app.batch.tracebill.job;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.barlow.core.enumerate.LegislationType;
+import com.barlow.core.enumerate.ProgressStatus;
+
+class PreviousBillsTest {
+
+	@Test
+	@DisplayName("getStatusByBillId가 null을 반환하는 billId가 있으면 NPE 없이 정상 반환되고 해당 billId는 UpdatedBills에 포함되지 않는다.")
+	void dirtyCheck_CurrentStatusIsNull_ReturnsWithoutNpeAndExcludesBillId() {
+		// given
+		PreviousBillBatchEntity previous = new PreviousBillBatchEntity(
+			"BILL-001", "테스트 법안", ProgressStatus.RECEIVED, LegislationType.EMPTY);
+		PreviousBills previousBills = new PreviousBills(List.of(previous));
+
+		CurrentBillInfoResult current = new CurrentBillInfoResult(Map.of());
+
+		// when
+		UpdatedBills result = previousBills.dirtyCheck(current);
+
+		// then — NPE 없이 정상 반환
+		assertThat(result).isNotNull();
+
+		// then — null 반환된 billId는 결과에 미포함
+		assertThat(result.isEmpty()).isTrue();
+	}
+
+	@Test
+	@DisplayName("getStatusByBillId가 이전 상태와 다른 값을 반환하면 해당 billId가 UpdatedBills에 포함된다.")
+	void dirtyCheck_CurrentStatusDiffersFromPrevious_IncludesBillIdInUpdatedBills() {
+		// given
+		PreviousBillBatchEntity previous = new PreviousBillBatchEntity(
+			"BILL-002", "상태변경 법안", ProgressStatus.RECEIVED, LegislationType.EMPTY);
+		PreviousBills previousBills = new PreviousBills(List.of(previous));
+
+		CurrentBillInfoResult current = new CurrentBillInfoResult(
+			Map.of("BILL-002", ProgressStatus.COMMITTEE_RECEIVED));
+
+		// when
+		UpdatedBills result = previousBills.dirtyCheck(current);
+
+		// then — 상태가 변경된 billId가 결과에 포함됨
+		assertThat(result.isEmpty()).isFalse();
+		List<UpdatedBills.BillInfo> committeeReceived = result.getCommitteeReceived();
+		assertThat(committeeReceived).hasSize(1);
+		assertThat(committeeReceived.get(0).billId()).isEqualTo("BILL-002");
+	}
+
+	@Test
+	@DisplayName("getStatusByBillId가 이전 상태와 동일한 값을 반환하면 해당 billId는 UpdatedBills에 포함되지 않는다.")
+	void dirtyCheck_CurrentStatusSameAsPrevious_ExcludesBillIdFromUpdatedBills() {
+		// given
+		PreviousBillBatchEntity previous = new PreviousBillBatchEntity(
+			"BILL-003", "상태동일 법안", ProgressStatus.RECEIVED, LegislationType.EMPTY);
+		PreviousBills previousBills = new PreviousBills(List.of(previous));
+
+		CurrentBillInfoResult current = new CurrentBillInfoResult(
+			Map.of("BILL-003", ProgressStatus.RECEIVED));
+
+		// when
+		UpdatedBills result = previousBills.dirtyCheck(current);
+
+		// then — 상태가 동일한 billId는 결과에 미포함
+		assertThat(result.isEmpty()).isTrue();
+	}
+
+	@Test
+	@DisplayName("모든 billId에 대해 getStatusByBillId가 null을 반환하면 빈 UpdatedBills가 NPE 없이 반환된다.")
+	void dirtyCheck_AllCurrentStatusesAreNull_ReturnsEmptyUpdatedBillsWithoutNpe() {
+		// given
+		List<PreviousBillBatchEntity> previousList = List.of(
+			new PreviousBillBatchEntity("BILL-010", "법안A", ProgressStatus.RECEIVED, LegislationType.EMPTY),
+			new PreviousBillBatchEntity("BILL-011", "법안B", ProgressStatus.COMMITTEE_REVIEW, LegislationType.EDUCATION),
+			new PreviousBillBatchEntity("BILL-012", "법안C", ProgressStatus.PLENARY_SUBMITTED, LegislationType.EMPTY));
+		PreviousBills previousBills = new PreviousBills(previousList);
+
+		CurrentBillInfoResult current = new CurrentBillInfoResult(Map.of());
+
+		// when
+		UpdatedBills result = previousBills.dirtyCheck(current);
+
+		// then — NPE 없이 빈 UpdatedBills 반환
+		assertThat(result).isNotNull();
+		assertThat(result.isEmpty()).isTrue();
+	}
+}


### PR DESCRIPTION
## 개요

`TraceBillDirtyCheckTasklet` 배치 작업 중 `BillTrackingClient` 응답에 특정 `billId`가 누락될 경우 `CurrentBillInfoResult.getStatusByBillId()`가 null을 반환하여 `.equals()` 호출 시 NPE가 발생하는 버그를 수정한다. `currentStatus` 로컬 변수 1회 추출 후 null 체크로 방어한다.


## 관련 이슈

- Closes #125


## 변경 유형

- [x] `fix` — 버그 수정


## 변경 레이어

- [x] `app:batch` — `PreviousBills.dirtyCheck()` null-safe 비교 로직 적용
- [x] `테스트` — `PreviousBillsTest` 단위 테스트 4개 추가


## 테스트

```bash
./gradlew :app:batch:unitTest
# BUILD SUCCESSFUL — PreviousBillsTest 4 tests passed
```


## 아키텍처 체크리스트

- [x] `core:domain` 에 Spring 어노테이션 없음
- [x] `core:service` 에서 `infra:*` 직접 import 없음
- [x] 도메인 객체 상태 변경 시 새 인스턴스 반환 (setter 없음)
- [x] 새 예외는 `CoreDomainException` 또는 `CoreApiException` 하위 + static factory
- [x] AR 간 참조는 ID-only (`long` 타입)


## 리뷰 포커스

`getStatusByBillId()` null 반환 시 해당 billId를 변경 대상에서 제외(skip)하는 정책이 적절한지 확인 부탁드립니다. API 응답에 billId가 누락된 경우 "상태 변경 없음"으로 간주하는 의도입니다.